### PR TITLE
Switch on/off the relative path use to create a symbolic link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Refactor application.
 
+## [0.10.0] - 2021-09-18
+
+### Added
+
+- Add the checkbox button on the application view to switch on/off the relative path use to create a symbolic link.
+- Implement the strategy for create new symlink with relative or absolute path.
+
 ## [0.9.0] - 2021-09-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Quick Symlink is a `Finder extension`  which provides a `contextual menu item` for the symbolic links creation on macOS. 
 
-[![status](https://img.shields.io/badge/status-active-active?style=flat-square)](BADGES_GUIDE.md#status) [![version](https://img.shields.io/badge/version-0.8.1-informational?style=flat-square)](BADGES_GUIDE.md#version) [![oss lifecycle](https://img.shields.io/badge/oss_lifecycle-active-important?style=flat-square)](BADGES_GUIDE.md#oss-lifecycle) [![maintenance](https://img.shields.io/badge/maintenance-yes-informational?style=flat-square)](BADGES_GUIDE.md#maintenance) [![last release](https://img.shields.io/badge/last_release-September_13,_2021-informational?style=flat-square)](BADGES_GUIDE.md#release-date) [![last commit](https://img.shields.io/badge/last_commit-September_13,_2021-informational?style=flat-square)](BADGES_GUIDE.md#commit-date)
+[![status](https://img.shields.io/badge/status-active-active?style=flat-square)](BADGES_GUIDE.md#status) [![version](https://img.shields.io/badge/version-0.10.0-informational?style=flat-square)](BADGES_GUIDE.md#version) [![oss lifecycle](https://img.shields.io/badge/oss_lifecycle-active-important?style=flat-square)](BADGES_GUIDE.md#oss-lifecycle) [![maintenance](https://img.shields.io/badge/maintenance-yes-informational?style=flat-square)](BADGES_GUIDE.md#maintenance) [![last release](https://img.shields.io/badge/last_release-September_18,_2021-informational?style=flat-square)](BADGES_GUIDE.md#release-date) [![last commit](https://img.shields.io/badge/last_commit-September_18,_2021-informational?style=flat-square)](BADGES_GUIDE.md#commit-date)
 
 [![license](https://img.shields.io/badge/license-MIT-informational?style=flat-square)](LICENSE) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg?style=flat-square)](CODE_OF_CONDUCT.md)
 
@@ -128,6 +128,10 @@ pluginkit -a quick-symlink.app/Contents/PlugIns/hard-link-action-extension.appex
 pluginkit -r quick-symlink.app/Contents/PlugIns/quick-symlink-extension.appex/
 pluginkit -r quick-symlink.app/Contents/PlugIns/hard-link-action-extension.appex/
 ```
+
+5. [OPTIONAL] Check/Uncheck the checkbox on the Application window "Use relative path for symlink" to use the relative path instead absolute path for the creating symlinks. **By default it's enabled**
+
+<img src="https://github.com/ololx/quick-symlink/blob/assets/use-relative.png?raw=true" width="30%"/>
 
 ### Downloading
 

--- a/commons/defaults/QuickSymlinkDefaults.swift
+++ b/commons/defaults/QuickSymlinkDefaults.swift
@@ -16,7 +16,7 @@ public struct QuickSymlinkDefaults<T> {
 public extension QuickSymlinkDefaults {
     
     func get() -> T {
-        guard let valueUntyped = UserDefaults.init(suiteName: "org.ololx.quick-symlink")?.object(forKey: self.key) else {
+        guard let valueUntyped = UserDefaults.init(suiteName: "org.ololx.QuickSymlink")?.object(forKey: self.key) else {
             return self.defaultValue;
         }
         
@@ -28,7 +28,7 @@ public extension QuickSymlinkDefaults {
     }
     
     func set(_ value: T) {
-        UserDefaults.init(suiteName: "org.ololx.quick-symlink")?.set(value, forKey: self.key);
+        UserDefaults.init(suiteName: "org.ololx.QuickSymlink")?.set(value, forKey: self.key);
     }
 }
 

--- a/quick-symlink.xcodeproj/project.pbxproj
+++ b/quick-symlink.xcodeproj/project.pbxproj
@@ -33,12 +33,12 @@
 		A345C9C226A0B30F004FBF0F /* CopyPathAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A345C9C126A0B30F004FBF0F /* CopyPathAction.swift */; };
 		A345C9C526A0B49C004FBF0F /* PasteLinkAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A345C9C426A0B49C004FBF0F /* PasteLinkAction.swift */; };
 		A345C9C826A0B552004FBF0F /* ReplaceWithLinkAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A345C9C726A0B552004FBF0F /* ReplaceWithLinkAction.swift */; };
+		A35AF46726F51A0B009546C3 /* QuickSymlinkDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DC975B26F4A3B800B506D4 /* QuickSymlinkDefaults.swift */; };
 		A36F9B0626DFAC27009E95CE /* FileLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36F9B0526DFAC27009E95CE /* FileLinkManager.swift */; };
 		A36F9B0726DFB127009E95CE /* FileLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36F9B0526DFAC27009E95CE /* FileLinkManager.swift */; };
 		A3DC975226F4662F00B506D4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A3DC975626F4662F00B506D4 /* Localizable.strings */; };
 		A3DC975326F4662F00B506D4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A3DC975626F4662F00B506D4 /* Localizable.strings */; };
 		A3DC975426F4662F00B506D4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A3DC975626F4662F00B506D4 /* Localizable.strings */; };
-		A3DC975C26F4A3B800B506D4 /* QuickSymlinkDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DC975B26F4A3B800B506D4 /* QuickSymlinkDefaults.swift */; };
 		A3DC975D26F4A3B800B506D4 /* QuickSymlinkDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DC975B26F4A3B800B506D4 /* QuickSymlinkDefaults.swift */; };
 		A3DC975E26F4A3B800B506D4 /* QuickSymlinkDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DC975B26F4A3B800B506D4 /* QuickSymlinkDefaults.swift */; };
 		A3E4D35526E0FD2900C9F175 /* FinderSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E4D35426E0FD2900C9F175 /* FinderSync.swift */; };
@@ -372,11 +372,22 @@
 					A30B9AA6265CA63300ACAA63 = {
 						CreatedOnToolsVersion = 9.2;
 						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.Mac = {
+								enabled = 1;
+							};
+							com.apple.Sandbox = {
+								enabled = 1;
+							};
+						};
 					};
 					A30B9ABD265CA68900ACAA63 = {
 						CreatedOnToolsVersion = 9.2;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
+							com.apple.ApplicationGroups.Mac = {
+								enabled = 1;
+							};
 							com.apple.Sandbox = {
 								enabled = 1;
 							};
@@ -464,7 +475,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A3DC975C26F4A3B800B506D4 /* QuickSymlinkDefaults.swift in Sources */,
 				A307B41A26D22116002EEF58 /* ResourcePath.swift in Sources */,
 				A345C9C826A0B552004FBF0F /* ReplaceWithLinkAction.swift in Sources */,
 				A316477726B7B403001DD969 /* CreateLinkAction.swift in Sources */,
@@ -472,6 +482,7 @@
 				A30B9AAD265CA63300ACAA63 /* ViewController.swift in Sources */,
 				A345C9C226A0B30F004FBF0F /* CopyPathAction.swift in Sources */,
 				A345C9BF26A0B200004FBF0F /* QuickSymlinkAction.swift in Sources */,
+				A35AF46726F51A0B009546C3 /* QuickSymlinkDefaults.swift in Sources */,
 				A30B9AAB265CA63300ACAA63 /* AppDelegate.swift in Sources */,
 				A345C9C526A0B49C004FBF0F /* PasteLinkAction.swift in Sources */,
 				A36F9B0626DFAC27009E95CE /* FileLinkManager.swift in Sources */,

--- a/quick-symlink/Base.lproj/Main.storyboard
+++ b/quick-symlink/Base.lproj/Main.storyboard
@@ -709,7 +709,23 @@
                     <view key="view" wantsLayer="YES" id="m2S-Jp-Qdl">
                         <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fIz-xt-1r7" userLabel="UseRelativePathCheckButton">
+                                <rect key="frame" x="18" y="18" width="201" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="Use relative path for symlinks" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="zpj-SC-3KW" userLabel="UseRelativePathCheckButton">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="onChange:" target="XfG-lQ-9wD" id="NYp-Ch-PbY"/>
+                                </connections>
+                            </button>
+                        </subviews>
                     </view>
+                    <connections>
+                        <outlet property="useRelativePath" destination="fIz-xt-1r7" id="nOg-Ve-aCb"/>
+                    </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/quick-symlink/ViewController.swift
+++ b/quick-symlink/ViewController.swift
@@ -9,11 +9,15 @@
 import Cocoa
 
 class ViewController: NSViewController {
+    
+    @IBOutlet weak var useRelativePath: NSButton!
+    
+    var quickSymlinkDefaults: QuickSymlinkDefaults! = QuickSymlinkDefaults(key: "relative-path-strategy", defaultValue: true);
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        self.useRelativePath.state = NSControl.StateValue(rawValue: quickSymlinkDefaults.get() ? 1 : 0);
     }
 
     override var representedObject: Any? {
@@ -22,6 +26,17 @@ class ViewController: NSViewController {
         }
     }
 
-
+    
+    @IBAction func onChange(_ sender: NSButton) {
+        switch sender.state {
+            case .on:
+                quickSymlinkDefaults.set(true);
+                break;
+            case .off:
+                quickSymlinkDefaults.set(false);
+                break;
+            default: break;
+        }
+    }
 }
 

--- a/quick-symlink/quick_symlink.entitlements
+++ b/quick-symlink/quick_symlink.entitlements
@@ -4,7 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>org.ololx.QuickSymlink</string>
+	</array>
 </dict>
 </plist>

--- a/soft-link-actions-extension/soft-link-actions-extension.entitlements
+++ b/soft-link-actions-extension/soft-link-actions-extension.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>org.ololx.QuickSymlink</string>
+	</array>
 	<key>com.apple.security.folders.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.temporary-exception.files.absolute-path.read-write</key>


### PR DESCRIPTION
## [0.10.0] - 2021-09-18

### Added

- Add the checkbox button on the application view to switch on/off the relative path use to create a symbolic link.
- Implement the strategy for create new symlink with relative or absolute path.